### PR TITLE
Additional information for manga

### DIFF
--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -514,6 +514,8 @@ South Korean
 - [https://www.justoon.co.kr](https://www.justoon.co.kr/)  
 - [http://toomics.com](http://toomics.com/)  
 - [http://bomtoon.com](http://bomtoon.com)
+- [https://toptoon.com/](https://toptoon.com/)
+- [https://m.mrblue.com/](https://m.mrblue.com/)
 :::
 
 ::: tab "Not Accepted"

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -489,49 +489,54 @@ If the work originally published on ‘_Not Accepted_‘ websites is later picke
 :::: tabs :options="{ useUrlFragment: false }"
 ::: tab Accepted
 Japanese  
-- [https://comic-walker.com](https://comic-walker.com/)  
 - [https://comic.pixiv.net](https://comic.pixiv.net/)  
-- [http://seiga.nicovideo.jp](http://seiga.nicovideo.jp/)  
+- [https://comic-walker.com](https://comic-walker.com/)  
 - [https://www.comico.jp](https://www.comico.jp/) \(Official works only, not Challenge\)  
-- [https://sai-zen-sen.jp](https://sai-zen-sen.jp/comics/twi4/)  
 - [https://piccoma.com](https://piccoma.com/web/)  
+- [https://sai-zen-sen.jp](https://sai-zen-sen.jp/comics/twi4/)  
+- [http://seiga.nicovideo.jp](http://seiga.nicovideo.jp/)  
 - [https://xoy.webtoons.com/ja](https://xoy.webtoons.com/ja) \(Official words only, not League\)
 
 Chinese  
 - [http://ac.qq.com](http://ac.qq.com)  
+- [https://www.dajiaochongmanhua.com](https://www.dajiaochongmanhua.com/)
+- [https://www.dongmanmanhua.cn/](https://www.dongmanmanhua.cn/)
+- [https://www.kaimanhua.com/](https://www.kaimanhua.com/)
 - [http://www.kuaikanmanhua.com](http://www.kuaikanmanhua.com/)  
 - [https://www.manmanapp.com](https://www.manmanapp.com/)  
 - [http://manhua.weibo.com](http://manhua.weibo.com/)  
-- [https://read.douban.com](https://read.douban.com/)  
-- [https://www.dajiaochongmanhua.com](https://www.dajiaochongmanhua.com/)
+- [https://www.manhuatai.com/](https://www.manhuatai.com/)
 - [https://manga.bilibili.com/](https://manga.bilibili.com/)
+- [https://read.douban.com](https://read.douban.com/)  
+- [https://www.zymk.cn/](https://www.zymk.cn/)
 
 South Korean  
-- [https://comic.naver.com](https://comic.naver.com/) \(Featured works only, not Challenge\)  
-- [http://webtoon.daum.net](http://webtoon.daum.net/) \(Official works only, not League\)  
-- [https://www.lezhin.com](https://www.lezhin.com/)  
-- [https://page.kakao.com](https://page.kakao.com/)  
-- [https://www.justoon.co.kr](https://www.justoon.co.kr/)  
-- [http://toomics.com](http://toomics.com/)  
 - [http://bomtoon.com](http://bomtoon.com)
-- [https://toptoon.com/](https://toptoon.com/)
+- [https://comic.naver.com](https://comic.naver.com/) \(Featured works only, not Challenge\)  
+- [https://www.justoon.co.kr](https://www.justoon.co.kr/)  
+- [https://www.lezhin.com](https://www.lezhin.com/)  
 - [https://m.mrblue.com/](https://m.mrblue.com/)
+- [https://page.kakao.com](https://page.kakao.com/)  
+- [http://toomics.com](http://toomics.com/)  
+- [https://toptoon.com/](https://toptoon.com/)
+- [http://webtoon.daum.net](http://webtoon.daum.net/) \(Official works only, not League\)  
 :::
 
 ::: tab "Not Accepted"
 Japanese  
+- [http://www.pixiv.net](http://pixiv.net/) \(However [PixivComics](https://comic.pixiv.net/) is allowed\)
 - [http://www.syosetu.com](http://syosetu.com/)  
 - [http://toko.takekuma.jp](http://toko.takekuma.jp/) \(However [Dennou Mavo](http://mavo.takekuma.jp/) is allowed\)  
-- [http://www.pixiv.net](http://pixiv.net/) \(However [PixivComics](https://comic.pixiv.net/) is allowed\)
 
 Chinese  
 - [http://u17.com](http://u17.com)
 
 Multi-language  
+- [https://www.smackjeeves.com/](https://www.smackjeeves.com/) \(Featured works on [Comico](https://www.comico.jp/) are allowed.\)
 - [https://www.tapas.io](https://tapas.io/)  
 - [https://www.twitter.com](https://www.twitter.com)  
-- [https://www.webtoons.com](https://www.webtoons.com/) \(Featured works on the Korean \([NAVER](https://comic.naver.com/)\) and Japanese \([XOY](https://xoy.webtoons.com/ja/)\) equivalents are allowed.\)
 - [https://www.webcomicsapp.com/](https://www.webcomicsapp.com/)
+- [https://www.webtoons.com](https://www.webtoons.com/) \(Featured works on the Korean \([NAVER](https://comic.naver.com/)\) and Japanese \([XOY](https://xoy.webtoons.com/ja/)\) equivalents are allowed.\)
 :::
 
 ::::

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -534,6 +534,7 @@ Chinese
 Multi-language  
 - [https://www.smackjeeves.com/](https://www.smackjeeves.com/) \(Featured works on [Comico](https://www.comico.jp/) are allowed.\)
 - [https://www.tapas.io](https://tapas.io/)  
+- [https://www.tappytoon.com/](https://www.tappytoon.com/)
 - [https://www.twitter.com](https://www.twitter.com)  
 - [https://www.webcomicsapp.com/](https://www.webcomicsapp.com/)
 - [https://www.webtoons.com](https://www.webtoons.com/) \(Featured works on the Korean \([NAVER](https://comic.naver.com/)\) and Japanese \([XOY](https://xoy.webtoons.com/ja/)\) equivalents are allowed.\)
@@ -541,6 +542,15 @@ Multi-language
 
 ::::
 
+Any submission that includes a link source from the multi-language section does not automatically result in a rejection. Try to find another source from the approved websites list, sometimes provided by MangaUpdates, and check to see if the native site's release dates occurred first.  
+
+Example 1: 
+
+> [_The Beloved Little Princess_](https://anilist.co/manga/117320/) was originally published by [KakaoPage](https://page.kakao.com/home?seriesId=54680399&page=1) on March 26, 2020 and later picked up by [Tappytoon](https://www.tappytoon.com/en/comics/beloved-little-princess).
+
+Example 2:
+
+> While it's available on [KakaoPage](https://page.kakao.com/home?seriesId=53142176) as of June 2019, _The Beginning After the End_ fails our qualifications as it was originally published by [Tapas](https://tapas.io/series/tbate-comic/info) on July 7, 2018.
 
 
 ## Sourcing

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -384,7 +384,7 @@ Light novels can be added to the website if they meet all the following criteria
 3. The light novel is specified as being such by the author, original publisher, or the majority of major Japanese retailers.
 
 ::: warning
-Should a light novel be promoted to a regular novel, or vice versa, the light novel may remain on the site so long as it's first publication is labeled as a light novel.
+Should a light novel be promoted to a regular novel, the light novel may remain on the site so long as its first publication is labeled as one.
 
 Example: [Koten-bu Series](https://anilist.co/manga/65513/Kotenbu-Series/) was initially published under the light novel label *Kadokawa Sneakers Bunko*, but moved to *Kadokawa Shoten* in 2005.
 :::
@@ -504,6 +504,7 @@ Chinese
 - [http://manhua.weibo.com](http://manhua.weibo.com/)  
 - [https://read.douban.com](https://read.douban.com/)  
 - [https://www.dajiaochongmanhua.com](https://www.dajiaochongmanhua.com/)
+- [https://manga.bilibili.com/](https://manga.bilibili.com/)
 
 South Korean  
 - [https://comic.naver.com](https://comic.naver.com/) \(Featured works only, not Challenge\)  
@@ -528,6 +529,7 @@ Multi-language
 - [https://www.tapas.io](https://tapas.io/)  
 - [https://www.twitter.com](https://www.twitter.com)  
 - [https://www.webtoons.com](https://www.webtoons.com/) \(Featured works on the Korean \([NAVER](https://comic.naver.com/)\) and Japanese \([XOY](https://xoy.webtoons.com/ja/)\) equivalents are allowed.\)
+- [https://www.webcomicsapp.com/](https://www.webcomicsapp.com/)
 :::
 
 ::::
@@ -721,6 +723,7 @@ Examples of how to deal with non-alphanumeric characters in titles can be seen i
 | 魔法少女2世 | [Mahou Shoujo 2-sei](https://anilist.co/manga/104770/Mahou-Shoujo-2sei/) |
 | 滅び時だと彼女は告げた \#異能犯罪捜査〈零局〉 | [Horobi Doki dato Kanojo wa Tsugeta \#InouHanzaiSousa &lt;Rei Kyoku&gt;](https://anilist.co/manga/104760/Horobi-Doki-dato-Kanojo-wa-Tsugeta-InouHanzaiSousa-Rei-Kyoku/) |
 | 政宗くんのリベンジafter school | [Masamune-kun no Revenge After School](https://anilist.co/manga/104896) |
+| 上を下へのジレッタ | [Ue wo Shita e no Jiretta](https://anilist.co/manga/106665/)
 
 
 ## Image Dimensions, and Templates

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -494,7 +494,7 @@ Japanese
 - [https://www.comico.jp](https://www.comico.jp/) \(Official works only, not Challenge\)  
 - [https://piccoma.com](https://piccoma.com/web/)  
 - [https://sai-zen-sen.jp](https://sai-zen-sen.jp/comics/twi4/)  
-- [http://seiga.nicovideo.jp](http://seiga.nicovideo.jp/)  
+- [http://seiga.nicovideo.jp](http://seiga.nicovideo.jp/) \(Only with the official \(公式\) serialization header\)
 - [https://xoy.webtoons.com/ja](https://xoy.webtoons.com/ja) \(Official words only, not League\)
 
 Chinese  
@@ -633,6 +633,7 @@ The romanization of names and titles is done in a variation of [Traditional Hepb
 * Loanwords are written properly in their respective languages  \(Example: _Maid_ instead of _Meido_\).  
 * Alternate spellings advocated by the creator\(s\) of the work are applied, if required.  
 * Things such as 'っち', 'っちゃ', and 'っちょ' are romanized as 'cchi', 'ccha', and 'ccho' respectively. This is opposed to the traditional 'tchi', 'tcha', and 'tcho'.  
+* 'を' is written as 'wo'.
 * 'ん' is always written as 'n'.  
 * Words adopted into English are written in that standard  \(Example: _Tokyo_ and _Osaka_ instead of _Toukyou_ and _Oosaka_ respectively\).  
 * Full-width punctuation should _**always**_ be converted to half-width or equivalent. \(。to . , ！to ! , ？to ?\)
@@ -649,6 +650,7 @@ Examples:
 | 乙女ゲー世界はモブに厳しい世界です | Otomege Sekai wa Mob ni Kibishii Sekai desu |
 | ふたご、ふたごころ。 | Futago, Futagokoro. |
 | 滅び時だと彼女は告げた \#異能犯罪捜査〈零局〉 | Horobi Doki dato Kanojo wa Tsugeta \#InouHanzaiSousa &lt;Rei Kyoku&gt; |
+| 君の膵臓をたべたい | [Kimi no Suizou wo Tabetai](https://anilist.co/anime/99750/)
 
 ### Title Modification
 
@@ -730,7 +732,6 @@ Examples of how to deal with non-alphanumeric characters in titles can be seen i
 | 魔法少女2世 | [Mahou Shoujo 2-sei](https://anilist.co/manga/104770/Mahou-Shoujo-2sei/) |
 | 滅び時だと彼女は告げた \#異能犯罪捜査〈零局〉 | [Horobi Doki dato Kanojo wa Tsugeta \#InouHanzaiSousa &lt;Rei Kyoku&gt;](https://anilist.co/manga/104760/Horobi-Doki-dato-Kanojo-wa-Tsugeta-InouHanzaiSousa-Rei-Kyoku/) |
 | 政宗くんのリベンジafter school | [Masamune-kun no Revenge After School](https://anilist.co/manga/104896) |
-| 上を下へのジレッタ | [Ue wo Shita e no Jiretta](https://anilist.co/manga/106665/)
 
 
 ## Image Dimensions, and Templates

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -650,7 +650,7 @@ Examples:
 | 乙女ゲー世界はモブに厳しい世界です | Otomege Sekai wa Mob ni Kibishii Sekai desu |
 | ふたご、ふたごころ。 | Futago, Futagokoro. |
 | 滅び時だと彼女は告げた \#異能犯罪捜査〈零局〉 | Horobi Doki dato Kanojo wa Tsugeta \#InouHanzaiSousa &lt;Rei Kyoku&gt; |
-| 君の膵臓をたべたい | [Kimi no Suizou wo Tabetai](https://anilist.co/anime/99750/)
+| 君の膵臓をたべたい | Kimi no Suizou wo Tabetai |
 
 ### Title Modification
 

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -220,7 +220,7 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 
 ### Chapters & Volumes
 
-The total number of chapters in the _**original**_ serialization of the work. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
+The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
 This exclude special pages for things such as advertising volume releases or author comments.
 

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -223,7 +223,7 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
 ::Tip
-Bonus chapters are ofter referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contents.
+Bonus chapters are often referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contents.
 ::
 
 This exclude special pages for things such as advertising volume releases or author comments.

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -222,15 +222,15 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 
 The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
-::Tip
-Bonus chapters are often referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contents.
-::
-
 This exclude special pages for things such as advertising volume releases or author comments.
 
 Volume and chapter counts are only added when the work is completed or confirmed complete. if the work is still publishing, both remain at _**zero**_.
 
 One-Shots should have the chapter count as _**one**_ and the volume count left as _**zero**_.
+
+::Tip
+Bonus chapters are often referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contents.
+::
 
 #### Volumes
 

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -220,9 +220,9 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 
 ### Chapters & Volumes
 
-The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
+The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters, and some prologues and epilogues.
 
-This exclude special pages for things such as advertising volume releases or author comments.
+This excludes special pages for things such as advertising volume releases or author comments.
 
 Volume and chapter counts are only added when the work is completed or confirmed complete. if the work is still publishing, both remain at _**zero**_.
 
@@ -237,7 +237,11 @@ Bonus chapters are often referred as 番外編 \(_Bangaihen_\) and 書き下ろ�
 The total number of volumes in the _**original**_ print or eBook run of the work.
 
 ::: warning
-The use of ‘original’ below is due to the fact that series can have new editions printed, omnibus volumes if licensed, etc. These can have different counts than the original runs.
+The use of ‘original’ above is due to the fact that series can have new editions printed, omnibus volumes if licensed, etc. These can have different counts than the original runs.
+:::
+
+::: warning
+If a specific manhwa or manhua title goes by 'seasons', the volume count must remain at _**zero**_. Instead, add the seasons and the amount of chapters it contains in the entry description.
 :::
 
 ### Genres
@@ -285,6 +289,12 @@ A basic, spoiler-free description of the entry. This should be in English and a 
 Descriptions use HTML.  
 Please use &lt;br&gt; for line breaks.  
 Links can be added as so: &lt;a href="website"&gt;NAME&lt;/a&gt;
+:::
+
+::: warning
+Do not source piracy sites for manga. Instead, look for a legal alternative, such as the official English licensor \(Example: Kodansha Comics\) or another English database \(Example: MangaUpdates\). 
+
+If no other alternative appears, use _\(Source: Japanese Publisher, translated\)_ or any equivalent of it.
 :::
 
 #### Formatting Best Practices

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -223,7 +223,7 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
 ::Tip
-Bonus chapters are ofter referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contexts.
+Bonus chapters are ofter referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contents.
 ::
 
 This exclude special pages for things such as advertising volume releases or author comments.

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -218,23 +218,23 @@ Please use the average length \(_**mode**_\) of episodes, rounded to the nearest
 The mean duration can be used for entries with wildly varying lengths, such as [Genius Party](https://anilist.co/anime/3508/GeniusParty).
 :::
 
-Volume and chapter counts are only added when the work is completed or confirmed complete. if the work is still publishing, both remain at _**zero**_.
-
-One-Shots should have the chapter count as _**one**_ and the volume count left as _**zero**_.
-
-::: warning
-The use of ‘original’ below is due to the fact that series can have new editions printed, omnibus volumes if licensed, etc. These can have different counts than the original runs.
-:::
-
 ### Chapters & Volumes
 
 The total number of chapters in the _**original**_ serialization of the work. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
-This does not exclude special pages for things such as advertising volume releases or author comments.
+This exclude special pages for things such as advertising volume releases or author comments.
+
+Volume and chapter counts are only added when the work is completed or confirmed complete. if the work is still publishing, both remain at _**zero**_.
+
+One-Shots should have the chapter count as _**one**_ and the volume count left as _**zero**_.
 
 #### Volumes
 
 The total number of volumes in the _**original**_ print or eBook run of the work.
+
+::: warning
+The use of ‘original’ below is due to the fact that series can have new editions printed, omnibus volumes if licensed, etc. These can have different counts than the original runs.
+:::
 
 ### Genres
 

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -222,6 +222,10 @@ The mean duration can be used for entries with wildly varying lengths, such as [
 
 The total number of chapters in the first edition of the physical volumes. Or, if volumes were never printed, the total number of chapters in the magazine/site the work was in. This does include things such as ‘side’ chapters \(Example: Chapter 5.5\), bonus chapters and some prologues and epilogues.
 
+::Tip
+Bonus chapters are ofter referred as 番外編 \(_Bangaihen_\) and 書き下ろし \(_Kakioroshi_\) in the table of contexts.
+::
+
 This exclude special pages for things such as advertising volume releases or author comments.
 
 Volume and chapter counts are only added when the work is completed or confirmed complete. if the work is still publishing, both remain at _**zero**_.

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -1035,7 +1035,7 @@ Lezhin (KO)
 Madman
 Manga Plus
 Manga.Club
-Mangabox
+Mangabox (JP)
 Manman Manhua (CN)
 Midnight Pulp
 Naver (KO)


### PR DESCRIPTION
Might want to squash the commits when you merge. 

- Got rid of the "vice versa" part from the light novel section.
- Added more external links for the web platform section
- More info regarding webtoons (at the request of Flidaix and SpinelSun)
- Added "wo" for romanization, following our traditional Hepburn requirement. 
- Added a tip for extras (at the request of Oterino)
- Added a warning for sourcing piracy sites. 